### PR TITLE
chore: s3 versino to use public module version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this module will be documented in this file.
 
-## [1.1.0] - 2022-07-22
+## [v1.1.1] - 2022-09-05
+
+### Changed
+
+- Update s3 module from version `v1.0.4` to public registry version `v1.1.2`
+
+## [v1.1.0] - 2022-07-22
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -87,20 +87,20 @@ module "lambda" {
 |---------------------------------------------------------------------------|----------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive)       | 2.2.0    |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 4.00  |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 4.0.0 |
 
 ## Providers
 
 | Name                                                          | Version |
 |---------------------------------------------------------------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0   |
-| <a name="provider_aws"></a> [aws](#provider\_aws)             | 4.23.0  |
+| <a name="provider_aws"></a> [aws](#provider\_aws)             | 4.29.0  |
 
 ## Modules
 
-| Name                                       | Source                                    | Version |
-|--------------------------------------------|-------------------------------------------|---------|
-| <a name="module_s3"></a> [s3](#module\_s3) | git@github.com:oozou/terraform-aws-s3.git | v1.0.4  |
+| Name                                       | Source       | Version |
+|--------------------------------------------|--------------|---------|
+| <a name="module_s3"></a> [s3](#module\_s3) | oozou/s3/aws | 1.1.2   |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,8 @@ data "archive_file" "this" {
 module "s3" {
   count = var.is_edge && var.is_create_lambda_bucket ? 1 : 0
 
-  source = "git@github.com:oozou/terraform-aws-s3.git?ref=v1.0.4"
+  source  = "oozou/s3/aws"
+  version = "1.1.2"
 
   prefix      = var.prefix
   environment = var.environment


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:

### Changed

- Update s3 module from version `v1.0.4` to public registry version `v1.1.2`

## Why :pleading_face:

- Fix security issue
